### PR TITLE
Fix names of a couple blocks

### DIFF
--- a/NTP/scripts/coilextractorlist.zs
+++ b/NTP/scripts/coilextractorlist.zs
@@ -7,7 +7,7 @@ static ExtractorInfoList as [ExtractorInfo] = [
 
 	ExtractorInfo("Redstone",0.80, "one lapisconverter coil || one diamondconverter coil"),
 	ExtractorInfo("Aluminium",0.90, "one emeraldconverter coil || one prismarineconverter coil || one redstoneextractor coil"),
-	ExtractorInfo("Copper",1.00, "one arsenicconverter coil || one carobiiteconverter coil || one aluminiumextractor coil"),
+	ExtractorInfo("Copper",1.00, "one arsenicconverter coil || one carobbiiteconverter coil || one aluminiumextractor coil"),
 	ExtractorInfo("Gold",1.10, "one fluoriteconverter coil || one rhodochrositeconverter coil || one copperextractor coil"),
 	ExtractorInfo("Beryllium",1.20, "one zirconiumconverter coil || one villiaumiteconverter coil || one goldextractor coil"),
 	ExtractorInfo("Graphite",1.30, "one glowstoneconverter coil || one quartzconverter coil || one berylliumextractor coil"),

--- a/NTP/scripts/coilstabilizerlist.zs
+++ b/NTP/scripts/coilstabilizerlist.zs
@@ -23,7 +23,7 @@ static StabilizerInfoList as [StabilizerInfo] = [
 	StabilizerInfo("LithiumManganeseDioxide",1.10, "one hslasteelstabilizer coil"),
 	StabilizerInfo("MagnesiumDiboride",1.15, "one lithiummanganesedioxidestabilizer coil || one tinmagnet coil"),
 	StabilizerInfo("Tough",1.20, "one magnesiumdiboridestabilizer coil || one ferroboronmagnet coil"),
-	StabilizerInfo("Extreme",1.30, "one coriumstabilizer coil || one siliconcarbidemagnet coil"),
+	StabilizerInfo("ExtremeAlloy",1.30, "one coriumstabilizer coil || one siliconcarbidemagnet coil"),
 	StabilizerInfo("SiCSiCCMC",1.45, "one extremealloystabilizer coil || one nakmagnet coil"),
 	StabilizerInfo("Sodium",1.50, "one sicsiccmcstabilizer coil"),
 	StabilizerInfo("BariumOxide",1.55, "one sodiumstabilizer coil || one potassiummagnet coil"),


### PR DESCRIPTION
- Fixed misspelling in Copper Extractor placement rule (caro**b**iite -> caro**bb**iite)
- Renamed `Extreme` stabilizer back to `ExtremeAlloy` (Current release shows ExtremeAlloy, as well as all other files in the repository (blockstate, lang, placement rules)